### PR TITLE
[Account] Signup 정책 및 password 사양 변경

### DIFF
--- a/src/main/java/org/codequistify/master/application/account/strategy/SignupPolicy.java
+++ b/src/main/java/org/codequistify/master/application/account/strategy/SignupPolicy.java
@@ -1,0 +1,59 @@
+package org.codequistify.master.application.account.strategy;
+
+import lombok.RequiredArgsConstructor;
+import org.codequistify.master.application.exception.ApplicationException;
+import org.codequistify.master.application.exception.ErrorCode;
+import org.codequistify.master.application.player.service.PlayerProfileService;
+import org.codequistify.master.core.domain.player.model.OAuthType;
+import org.codequistify.master.core.domain.player.service.PlayerValidator;
+import org.codequistify.master.core.domain.vo.Email;
+import org.codequistify.master.infrastructure.player.repository.PlayerRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import java.util.function.Predicate;
+
+@Component
+@RequiredArgsConstructor
+public class SignupPolicy {
+
+    private final PlayerProfileService playerProfileService;
+    private final PlayerRepository playerRepository;
+    private final PlayerValidator playerValidator;
+
+    public void validate(String name, Email email, String password) {
+        validateEmailNotTaken(email);
+        validatePassword(password);
+        validateName(name);
+        validateNameUniqueness(name);
+    }
+
+    private void validateEmailNotTaken(Email email) {
+        playerRepository.getOAuthTypeByEmail(email).ifPresent(authType -> {
+            ErrorCode code = authType.equals(OAuthType.POL)
+                    ? ErrorCode.EMAIL_ALREADY_EXISTS
+                    : ErrorCode.EMAIL_ALREADY_EXISTS_OTHER_AUTH;
+            throw new ApplicationException(code, HttpStatus.BAD_REQUEST, authType.name());
+        });
+    }
+
+    private void validatePassword(String password) {
+        Predicate<String> validPassword = playerValidator::isValidPassword;
+        if (!validPassword.test(password)) {
+            throw new ApplicationException(ErrorCode.PASSWORD_POLICY_VIOLATION, HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private void validateName(String name) {
+        Predicate<String> validName = playerValidator::isValidName;
+        if (!validName.test(name)) {
+            throw new ApplicationException(ErrorCode.PROFANITY_IN_NAME, HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private void validateNameUniqueness(String name) {
+        if (playerProfileService.isDuplicatedName(name)) {
+            throw new ApplicationException(ErrorCode.DUPLICATE_NAME, HttpStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/src/main/java/org/codequistify/master/core/domain/player/model/HashedPassword.java
+++ b/src/main/java/org/codequistify/master/core/domain/player/model/HashedPassword.java
@@ -1,0 +1,29 @@
+package org.codequistify.master.core.domain.player.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.codequistify.master.core.exception.CoreException;
+
+@EqualsAndHashCode
+@ToString
+public class HashedPassword {
+
+    private final String value;
+
+    private HashedPassword(String value) {
+        this.value = value;
+    }
+
+    public static HashedPassword fromHashed(String hashed) {
+        if (hashed == null || hashed.isBlank()) {
+            throw new CoreException("비밀번호는 null이 될 수 없습니다.");
+        }
+        return new HashedPassword(hashed);
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/org/codequistify/master/core/domain/player/model/Player.java
+++ b/src/main/java/org/codequistify/master/core/domain/player/model/Player.java
@@ -22,7 +22,7 @@ public class Player {
     private final String oAuthAccessToken;
     private final String oAuthId;
     private final OAuthType oAuthType;
-    private final String password;
+    private final HashedPassword password;
     private final String refreshToken;
     private final Set<String> roles;
     private final PolId uid;

--- a/src/main/java/org/codequistify/master/core/domain/player/service/PlayerPasswordManager.java
+++ b/src/main/java/org/codequistify/master/core/domain/player/service/PlayerPasswordManager.java
@@ -12,19 +12,11 @@ public class PlayerPasswordManager {
         this.encoder = encoder;
     }
 
-    public Player encodePassword(Player player) {
-        return player.toBuilder()
-                     .password(encoder.encode(player.getPassword()))
-                     .build();
-    }
-
-    public Player encodePassword(Player player, String rawPassword) {
-        return player.toBuilder()
-                     .password(encoder.encode(rawPassword))
-                     .build();
+    public String encode(String rawPassword) {
+        return encoder.encode(rawPassword);
     }
 
     public boolean matches(Player player, String rawPassword) {
-        return encoder.matches(rawPassword, player.getPassword());
+        return encoder.matches(rawPassword, player.getPassword().getValue());
     }
 }

--- a/src/main/java/org/codequistify/master/infrastructure/player/converter/HashedPasswordConverter.java
+++ b/src/main/java/org/codequistify/master/infrastructure/player/converter/HashedPasswordConverter.java
@@ -1,0 +1,19 @@
+package org.codequistify.master.infrastructure.player.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.codequistify.master.core.domain.player.model.HashedPassword;
+
+@Converter(autoApply = true)
+public class HashedPasswordConverter implements AttributeConverter<HashedPassword, String> {
+
+    @Override
+    public String convertToDatabaseColumn(HashedPassword attribute) {
+        return attribute != null ? attribute.getValue() : null;
+    }
+
+    @Override
+    public HashedPassword convertToEntityAttribute(String dbData) {
+        return dbData != null ? HashedPassword.fromHashed(dbData) : null;
+    }
+}

--- a/src/test/java/org/codequistify/master/domain/player/service/AccountServiceTest.java
+++ b/src/test/java/org/codequistify/master/domain/player/service/AccountServiceTest.java
@@ -1,10 +1,10 @@
 package org.codequistify.master.domain.player.service;
 
-import org.codequistify.master.application.account.dto.LogInRequest;
-import org.codequistify.master.application.account.dto.SignUpRequest;
 import org.codequistify.master.application.account.service.AccountService;
+import org.codequistify.master.application.exception.ApplicationException;
 import org.codequistify.master.application.exception.ErrorCode;
-import org.codequistify.master.application.player.dto.PlayerProfile;
+import org.codequistify.master.core.domain.player.model.Player;
+import org.codequistify.master.core.domain.vo.Email;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,84 +29,65 @@ class AccountServiceTest {
 
     @BeforeEach
     void setUp() {
-        SignUpRequest request = new SignUpRequest("A", "A@pol.or.kr", "password99763892*");
-        PlayerProfile result = accountService.signUp(request);
+        accountService.signUp("A", Email.of("A@pol.or.kr"), "password99763892*");
     }
-
 
     @Test
     @Order(1)
-    public void 회원가입_성공(){
-        SignUpRequest request = new SignUpRequest("B", "B@pol.or.kr", "password99763892*");
-        PlayerProfile result = accountService.signUp(request);
+    public void 회원가입_성공() {
+        Player result = accountService.signUp("B", Email.of("B@pol.or.kr"), "password99763892*");
 
         assertNotNull(result);
-        assertEquals(request.name(), result.name());
-        assertEquals(request.email(), result.email());
+        assertEquals("B", result.getName());
+        assertEquals(Email.of("B@pol.or.kr"), result.getEmail());
     }
 
     @Test
-    public void 중복_회원가입(){
-        SignUpRequest request = new SignUpRequest("A", "A@pol.or.kr", "password99763892*");
-
-        Throwable ex = assertThrows(ApplicationException.class, () -> {
-            accountService.signUp(request);
+    @Order(2)
+    public void 중복_회원가입() {
+        ApplicationException ex = assertThrows(ApplicationException.class, () -> {
+            accountService.signUp("A", Email.of("A@pol.or.kr"), "password99763892*");
         });
+
         assertEquals(ErrorCode.EMAIL_ALREADY_EXISTS.getMessage(), ex.getMessage());
     }
 
-    /*@Test
-    public void 이메일_양식_미충족(){
-        SignUpRequest request = new SignUpRequest("C", "", "password99763892*");
-
-        Throwable ex = assertThrows(ApplicationException.class, () -> {
-            authenticationService.signUp(request);
-        });
-        assertEquals(ErrorCode.INVALID_EMAIL_FORMAT.getMessage(), ex.getMessage());
-    }*/
-
     @Test
-    public void 비밀번호_조건_미충족(){
-        SignUpRequest request = new SignUpRequest("D", "D@pol.or.kr", "pass63892");
-
-        Throwable ex = assertThrows(ApplicationException.class, () -> {
-            accountService.signUp(request);
+    @Order(3)
+    public void 비밀번호_조건_미충족() {
+        ApplicationException ex = assertThrows(ApplicationException.class, () -> {
+            accountService.signUp("D", Email.of("D@pol.or.kr"), "pass63892");
         });
+
         assertEquals(ErrorCode.PASSWORD_POLICY_VIOLATION.getMessage(), ex.getMessage());
     }
 
     @Test
+    @Order(4)
     public void 정상_로그인() {
-        LogInRequest request = new LogInRequest("A@pol.or.kr", "password99763892*");
-
-        PlayerProfile result = accountService.logIn(request);
+        Player result = accountService.logIn(Email.of("A@pol.or.kr"), "password99763892*");
 
         assertNotNull(result);
-        assertEquals(request.email(), result.email());
+        assertEquals(Email.of("A@pol.or.kr"), result.getEmail());
     }
 
-    //로그인 비밀번호 오류
     @Test
+    @Order(5)
     public void 로그인_비밀번호_오류() {
-        LogInRequest request = new LogInRequest("A@pol.or.kr", "wrong");
-
-        Throwable ex = assertThrows(ApplicationException.class, () -> {
-            accountService.logIn(request);
+        ApplicationException ex = assertThrows(ApplicationException.class, () -> {
+            accountService.logIn(Email.of("A@pol.or.kr"), "wrong");
         });
+
         assertEquals(ErrorCode.INVALID_EMAIL_OR_PASSWORD.getMessage(), ex.getMessage());
     }
 
-    //로그인 이메일 오류
     @Test
+    @Order(6)
     public void 로그인_이메일_오류() {
-        LogInRequest request = new LogInRequest("wrong@pol.or.kr", "password99763892*");
-
-        Throwable ex = assertThrows(ApplicationException.class, () -> {
-            accountService.logIn(request);
+        ApplicationException ex = assertThrows(ApplicationException.class, () -> {
+            accountService.logIn(Email.of("wrong@pol.or.kr"), "password99763892*");
         });
+
         assertEquals(ErrorCode.INVALID_EMAIL_OR_PASSWORD.getMessage(), ex.getMessage());
     }
-
-
-
 }


### PR DESCRIPTION
# Summary
Signup시에 적용되는 비밀번호 해싱과 유효성검증 로직을 개선합니다.

# Description
### HashedPassword 도입
기존에는 `String` 클래스를 통해 password를 입력하여, raw인지 hash인지 구분이 불가능했습니다. 
- `HasedPassword` 클래스로 `String`을 alias하도록 수정하여 player 생성 이전에 반드시 인코딩을 하도록 강제하였습니다.
- Json과 Jpa 직렬화를 반영해주었습니다.

### Signup Policy 관리 추가
Signup Policy 로직이 서비스안에서 혼자 비대해지고 분기가 많이지고 있어서 기능을 분리합니다.
- 회원가입 정책만 관리하는 `SignupPolicy`를 추가하였습니다.
- 개별적인 검증로직을 작성하고, 통합실행하는 메서드를 따로 두어 확장에 유리하도록하였습니다.
